### PR TITLE
Added Demo App changes for Mono/Stereo Audio Mode and Updated SDK Tests

### DIFF
--- a/AmazonChimeSDK/AmazonChimeSDK.xcodeproj/project.pbxproj
+++ b/AmazonChimeSDK/AmazonChimeSDK.xcodeproj/project.pbxproj
@@ -179,9 +179,9 @@
 		7CE107642421CC7B00E209D1 /* ActiveSpeakerDetectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CE107602421CC7B00E209D1 /* ActiveSpeakerDetectorTests.swift */; };
 		7CE107652421CC7B00E209D1 /* ActiveSpeakerPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CE107612421CC7B00E209D1 /* ActiveSpeakerPolicyTests.swift */; };
 		7CE107662421CC7B00E209D1 /* SchedulerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CE107632421CC7B00E209D1 /* SchedulerTests.swift */; };
-		8278478927188CA00071E7BE /* AudioMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8278478827188CA00071E7BE /* AudioMode.swift */; };
+		820288D42735997100B0B5D3 /* AudioMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 820288D32735997100B0B5D3 /* AudioMode.swift */; };
+		820288D827359A1400B0B5D3 /* AudioModeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 820288D727359A1400B0B5D3 /* AudioModeTests.swift */; };
 		8278478D27188D110071E7BE /* AudioVideoConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8278478C27188D110071E7BE /* AudioVideoConfiguration.swift */; };
-		827847BF271D13A90071E7BE /* AudioModeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 827847BE271D13A90071E7BE /* AudioModeTests.swift */; };
 		827847C3271D15B20071E7BE /* AudioVideoConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 827847C2271D15B20071E7BE /* AudioVideoConfigurationTests.swift */; };
 		827847C7271D16E20071E7BE /* DefaultAudioVideoFacadeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 827847C6271D16E20071E7BE /* DefaultAudioVideoFacadeTests.swift */; };
 		AC865DC0271F9B4600D6A0D8 /* MockedAudioSessionPortDescription.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC865DBF271F9B4600D6A0D8 /* MockedAudioSessionPortDescription.swift */; };
@@ -448,9 +448,9 @@
 		7CE107602421CC7B00E209D1 /* ActiveSpeakerDetectorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ActiveSpeakerDetectorTests.swift; sourceTree = "<group>"; };
 		7CE107612421CC7B00E209D1 /* ActiveSpeakerPolicyTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ActiveSpeakerPolicyTests.swift; sourceTree = "<group>"; };
 		7CE107632421CC7B00E209D1 /* SchedulerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SchedulerTests.swift; sourceTree = "<group>"; };
-		8278478827188CA00071E7BE /* AudioMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioMode.swift; sourceTree = "<group>"; };
+		820288D32735997100B0B5D3 /* AudioMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioMode.swift; sourceTree = "<group>"; };
+		820288D727359A1400B0B5D3 /* AudioModeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioModeTests.swift; sourceTree = "<group>"; };
 		8278478C27188D110071E7BE /* AudioVideoConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioVideoConfiguration.swift; sourceTree = "<group>"; };
-		827847BE271D13A90071E7BE /* AudioModeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioModeTests.swift; sourceTree = "<group>"; };
 		827847C2271D15B20071E7BE /* AudioVideoConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioVideoConfigurationTests.swift; sourceTree = "<group>"; };
 		827847C6271D16E20071E7BE /* DefaultAudioVideoFacadeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultAudioVideoFacadeTests.swift; sourceTree = "<group>"; };
 		AC865DBF271F9B4600D6A0D8 /* MockedAudioSessionPortDescription.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockedAudioSessionPortDescription.swift; sourceTree = "<group>"; };
@@ -849,7 +849,7 @@
 				5A631A4124297C9600C8DAF3 /* activespeakerdetector */,
 				5A631A4224297CC200C8DAF3 /* activespeakerpolicy */,
 				7C0D1BCA241ACC7B00280031 /* scheduler */,
-				8278478827188CA00071E7BE /* AudioMode.swift */,
+				820288D32735997100B0B5D3 /* AudioMode.swift */,
 			);
 			path = audio;
 			sourceTree = "<group>";
@@ -1008,7 +1008,7 @@
 				7CE107602421CC7B00E209D1 /* ActiveSpeakerDetectorTests.swift */,
 				7CE107612421CC7B00E209D1 /* ActiveSpeakerPolicyTests.swift */,
 				7CE107632421CC7B00E209D1 /* SchedulerTests.swift */,
-				827847BE271D13A90071E7BE /* AudioModeTests.swift */,
+				820288D727359A1400B0B5D3 /* AudioModeTests.swift */,
 			);
 			path = audio;
 			sourceTree = "<group>";
@@ -1412,7 +1412,7 @@
 			files = (
 			);
 			inputPaths = (
-				"/tmp/Mockingbird-308DA08D-EE8C-48F1-9894-E440336D8EA4",
+				"/tmp/Mockingbird-77A0DDE8-21D8-4190-9F7F-FE72495E6ED5",
 			);
 			name = "Generate Mockingbird Mocks";
 			outputPaths = (
@@ -1420,7 +1420,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "set -e\n\nmockingbird generate \\\n  --targets 'AmazonChimeSDK' \\\n  --outputs \"${SRCROOT}/MockingbirdMocks/AmazonChimeSDKTests-AmazonChimeSDKMocks.generated.swift\" \\\n  --support \"${SRCROOT}/MockingbirdSupport\"\n\n# Ensure mocks are generated prior to running Compile Sources\nrm -f '/tmp/Mockingbird-308DA08D-EE8C-48F1-9894-E440336D8EA4'\n";
+			shellScript = "set -e\n\nmockingbird generate \\\n  --targets 'AmazonChimeSDK' \\\n  --outputs \"${SRCROOT}/MockingbirdMocks/AmazonChimeSDKTests-AmazonChimeSDKMocks.generated.swift\" \\\n  --support \"${SRCROOT}/MockingbirdSupport\"\n\n# Ensure mocks are generated prior to running Compile Sources\nrm -f '/tmp/Mockingbird-77A0DDE8-21D8-4190-9F7F-FE72495E6ED5'\n";
 		};
 		114854BF06996650440AB080 /* Clean Mockingbird Mocks */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -1431,11 +1431,11 @@
 			);
 			name = "Clean Mockingbird Mocks";
 			outputPaths = (
-				"/tmp/Mockingbird-308DA08D-EE8C-48F1-9894-E440336D8EA4",
+				"/tmp/Mockingbird-77A0DDE8-21D8-4190-9F7F-FE72495E6ED5",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "echo $RANDOM > '/tmp/Mockingbird-308DA08D-EE8C-48F1-9894-E440336D8EA4'\n";
+			shellScript = "echo $RANDOM > '/tmp/Mockingbird-77A0DDE8-21D8-4190-9F7F-FE72495E6ED5'\n";
 		};
 		5A3CFC6423C52B5D00BB63B7 /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -1518,6 +1518,7 @@
 				002C1FAC2641C50000C9B919 /* EventAttributesUtils.swift in Sources */,
 				00D12B8B265F02130059461B /* NoopEventReporterFactory.swift in Sources */,
 				C4643F0625784EEB0085D51E /* DefaultModality.swift in Sources */,
+				820288D42735997100B0B5D3 /* AudioMode.swift in Sources */,
 				5A6A209923CB1164000C9157 /* DefaultMeetingSession.swift in Sources */,
 				0083A11623D8CFFD0057027A /* DefaultRealtimeController.swift in Sources */,
 				00D9DBB2241AE23F00146467 /* DefaultVideoClient.swift in Sources */,
@@ -1563,7 +1564,6 @@
 				6AA9F9462522439F00EB0644 /* VideoSink.swift in Sources */,
 				B418163024B79C0600FA62BF /* DataMessage.swift in Sources */,
 				0068454926125063002AB143 /* SDKEvent.swift in Sources */,
-				8278478927188CA00071E7BE /* AudioMode.swift in Sources */,
 				002C1FB72642099F00C9B919 /* DefaultBackoffRetry.swift in Sources */,
 				003B588923E22C4F002493AB /* MeetingSessionStatus.swift in Sources */,
 				0064165926290BDB00626EB8 /* EventDao.swift in Sources */,
@@ -1651,12 +1651,12 @@
 				5A2210E524BE577E0038725B /* DefaultMeetingSessionTests.swift in Sources */,
 				00E198E1259BC0CF00AD4DAA /* EventNameTests.swift in Sources */,
 				00E198EF259BCA5A00AD4DAA /* EventAttributeNameTests.swift in Sources */,
+				820288D827359A1400B0B5D3 /* AudioModeTests.swift in Sources */,
 				6A01CAE523F8FCAF005C5193 /* ClientMetricsCollectorTests.swift in Sources */,
 				007679FE262DFAE500BBF977 /* DirtyEventSQLiteDaoTests.swift in Sources */,
 				C4A30003259D4261007CFABE /* DefaultContentShareControllerTests.swift in Sources */,
 				C67EA02A26F7F0EB0084C9B4 /* TranscriptItemTypeTests.swift in Sources */,
 				002F8FEF25BFED6800006F46 /* DefaultMeetingStatsCollectorTests.swift in Sources */,
-				827847BF271D13A90071E7BE /* AudioModeTests.swift in Sources */,
 				5AE1322F23EA2FB700BF5997 /* ConsoleLoggerTests.swift in Sources */,
 				5A16C0052405E83000ADAE26 /* DictionaryExtensionTests.swift in Sources */,
 				00684538260D1F1E002AB143 /* SQLiteClientFileTests.swift in Sources */,

--- a/AmazonChimeSDK/AmazonChimeSDK.xcodeproj/project.pbxproj
+++ b/AmazonChimeSDK/AmazonChimeSDK.xcodeproj/project.pbxproj
@@ -1412,7 +1412,7 @@
 			files = (
 			);
 			inputPaths = (
-				"/tmp/Mockingbird-77A0DDE8-21D8-4190-9F7F-FE72495E6ED5",
+				"/tmp/Mockingbird-843A55A6-F172-40F8-AD36-AE309CDDCACD",
 			);
 			name = "Generate Mockingbird Mocks";
 			outputPaths = (
@@ -1420,7 +1420,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "set -e\n\nmockingbird generate \\\n  --targets 'AmazonChimeSDK' \\\n  --outputs \"${SRCROOT}/MockingbirdMocks/AmazonChimeSDKTests-AmazonChimeSDKMocks.generated.swift\" \\\n  --support \"${SRCROOT}/MockingbirdSupport\"\n\n# Ensure mocks are generated prior to running Compile Sources\nrm -f '/tmp/Mockingbird-77A0DDE8-21D8-4190-9F7F-FE72495E6ED5'\n";
+			shellScript = "set -e\n\nmockingbird generate \\\n  --targets 'AmazonChimeSDK' \\\n  --outputs \"${SRCROOT}/MockingbirdMocks/AmazonChimeSDKTests-AmazonChimeSDKMocks.generated.swift\" \\\n  --support \"${SRCROOT}/MockingbirdSupport\"\n\n# Ensure mocks are generated prior to running Compile Sources\nrm -f '/tmp/Mockingbird-843A55A6-F172-40F8-AD36-AE309CDDCACD'\n";
 		};
 		114854BF06996650440AB080 /* Clean Mockingbird Mocks */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -1431,11 +1431,11 @@
 			);
 			name = "Clean Mockingbird Mocks";
 			outputPaths = (
-				"/tmp/Mockingbird-77A0DDE8-21D8-4190-9F7F-FE72495E6ED5",
+				"/tmp/Mockingbird-843A55A6-F172-40F8-AD36-AE309CDDCACD",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "echo $RANDOM > '/tmp/Mockingbird-77A0DDE8-21D8-4190-9F7F-FE72495E6ED5'\n";
+			shellScript = "echo $RANDOM > '/tmp/Mockingbird-843A55A6-F172-40F8-AD36-AE309CDDCACD'\n";
 		};
 		5A3CFC6423C52B5D00BB63B7 /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/AmazonChimeSDK/AmazonChimeSDK/audiovideo/AudioVideoConfiguration.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/audiovideo/AudioVideoConfiguration.swift
@@ -14,7 +14,7 @@ import Foundation
     public let callKitEnabled: Bool
 
     convenience override public init() {
-        self.init(audioMode: .mono, callKitEnabled: false)
+        self.init(audioMode: .stereo48K, callKitEnabled: false)
     }
 
     convenience public init(audioMode: AudioMode) {
@@ -22,7 +22,7 @@ import Foundation
     }
 
     convenience public init(callKitEnabled: Bool) {
-        self.init(audioMode: .mono, callKitEnabled: callKitEnabled)
+        self.init(audioMode: .stereo48K, callKitEnabled: callKitEnabled)
     }
 
     public init(audioMode: AudioMode, callKitEnabled: Bool) {

--- a/AmazonChimeSDK/AmazonChimeSDK/audiovideo/audio/AudioMode.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/audiovideo/audio/AudioMode.swift
@@ -13,15 +13,25 @@ import Foundation
     /// There will be no audio through mic and speaker
     case noAudio = 0
 
-    /// The default audio mode with single audio channel
-    case mono = 1
+    /// The mono audio mode with single audio channel and 16KHz
+    case mono16K = 1
+
+    /// The mono audio mode with single audio channel and 48KHz
+    case mono48K = 2
+
+    /// The stereo audio mode with two audio channels and 48KHz
+    case stereo48K = 3
 
     public var description: String {
         switch self {
         case .noAudio:
             return "noAudio"
-        case .mono:
-            return "mono"
+        case .mono16K:
+            return "mono16K"
+        case .mono48K:
+            return "mono48K"
+        case .stereo48K:
+            return "stereo48K"
         }
     }
 }

--- a/AmazonChimeSDK/AmazonChimeSDK/internal/audio/DefaultAudioClientController.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/internal/audio/DefaultAudioClientController.swift
@@ -99,6 +99,14 @@ extension DefaultAudioClientController: AudioClientController {
         eventAnalyticsController.publishEvent(name: .meetingStartRequested)
         let appInfo = DeviceUtils.getAppInfo()
         muteMicAndSpeaker = audioMode == .noAudio
+        var audioModeNative: AudioModeInternal = .Stereo48K
+        if (audioMode == .mono48K) {
+            audioModeNative = .Mono48K
+        } else if (audioMode == .mono16K) {
+            audioModeNative = .Mono16K
+        } else if (audioMode == .noAudio) {
+            audioModeNative = .NoAudio
+        }
         let status = audioClient.startSession(host,
                                               basePort: port,
                                               callId: meetingId,
@@ -109,7 +117,8 @@ extension DefaultAudioClientController: AudioClientController {
                                               sessionToken: joinToken,
                                               audioWsUrl: audioFallbackUrl,
                                               callKitEnabled: callKitEnabled,
-                                              appInfo: appInfo)
+                                              appInfo: appInfo,
+                                              audioMode: audioModeNative)
 
         if status == AUDIO_CLIENT_OK {
             Self.state = .started

--- a/AmazonChimeSDK/AmazonChimeSDK/internal/audio/DefaultAudioClientController.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/internal/audio/DefaultAudioClientController.swift
@@ -99,13 +99,13 @@ extension DefaultAudioClientController: AudioClientController {
         eventAnalyticsController.publishEvent(name: .meetingStartRequested)
         let appInfo = DeviceUtils.getAppInfo()
         muteMicAndSpeaker = audioMode == .noAudio
-        var audioModeNative: AudioModeInternal = .Stereo48K
+        var audioModeInternal: AudioModeInternal = .Stereo48K
         if (audioMode == .mono48K) {
-            audioModeNative = .Mono48K
+            audioModeInternal = .Mono48K
         } else if (audioMode == .mono16K) {
-            audioModeNative = .Mono16K
+            audioModeInternal = .Mono16K
         } else if (audioMode == .noAudio) {
-            audioModeNative = .NoAudio
+            audioModeInternal = .NoAudio
         }
         let status = audioClient.startSession(host,
                                               basePort: port,
@@ -118,7 +118,7 @@ extension DefaultAudioClientController: AudioClientController {
                                               audioWsUrl: audioFallbackUrl,
                                               callKitEnabled: callKitEnabled,
                                               appInfo: appInfo,
-                                              audioMode: audioModeNative)
+                                              audioMode: audioModeInternal)
 
         if status == AUDIO_CLIENT_OK {
             Self.state = .started

--- a/AmazonChimeSDK/AmazonChimeSDK/internal/audio/protocols/AudioClientProtocol.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/internal/audio/protocols/AudioClientProtocol.swift
@@ -23,6 +23,20 @@ import Foundation
                       callKitEnabled: Bool,
                       appInfo: AppInfo!) -> audio_client_status_t
 
+    // swiftlint:disable function_parameter_count variable_name
+    func startSession(_ host: String!,
+                      basePort port: Int,
+                      callId: String!,
+                      profileId: String!,
+                      microphoneMute mic_mute: Bool,
+                      speakerMute spk_mute: Bool,
+                      isPresenter presenter: Bool,
+                      sessionToken tokenString: String!,
+                      audioWsUrl: String!,
+                      callKitEnabled: Bool,
+                      appInfo: AppInfo!,
+                      audioMode: AudioModeInternal) -> audio_client_status_t
+
     func startSession(_ host: String!,
                       basePort port: Int,
                       callId: String!,
@@ -55,9 +69,9 @@ import Foundation
     func isBliteNSSelected() -> Bool
 
     func setBliteNSSelected(_ bliteSelected: Bool) -> Int
-    
+
     func endOnHold()
-    
+
     var delegate: AudioClientDelegate! { get set }
 }
 

--- a/AmazonChimeSDK/AmazonChimeSDKTests/audiovideo/AudioVideoConfigurationTests.swift
+++ b/AmazonChimeSDK/AmazonChimeSDKTests/audiovideo/AudioVideoConfigurationTests.swift
@@ -12,15 +12,27 @@ import XCTest
 class AudioVideoConfigurationTests: XCTestCase {
     func testDefaultConfigurations() {
         let audioVideoConfig = AudioVideoConfiguration()
-        XCTAssertEqual(audioVideoConfig.audioMode, .mono)
+        XCTAssertEqual(audioVideoConfig.audioMode, .stereo48K)
         XCTAssertEqual(audioVideoConfig.callKitEnabled, false)
 
-        let audioVideoConfigAudioMode = AudioVideoConfiguration(audioMode: .noAudio)
-        XCTAssertEqual(audioVideoConfigAudioMode.audioMode, .noAudio)
+        let audioVideoConfigAudioMode = AudioVideoConfiguration(audioMode: .stereo48K)
+        XCTAssertEqual(audioVideoConfigAudioMode.audioMode, .stereo48K)
         XCTAssertEqual(audioVideoConfigAudioMode.callKitEnabled, false)
 
+        let audioVideoConfigAudioModeMono48K = AudioVideoConfiguration(audioMode: .mono48K)
+        XCTAssertEqual(audioVideoConfigAudioModeMono48K.audioMode, .mono48K)
+        XCTAssertEqual(audioVideoConfigAudioModeMono48K.callKitEnabled, false)
+
+        let audioVideoConfigAudioModeMono16K = AudioVideoConfiguration(audioMode: .mono16K)
+        XCTAssertEqual(audioVideoConfigAudioModeMono16K.audioMode, .mono16K)
+        XCTAssertEqual(audioVideoConfigAudioModeMono16K.callKitEnabled, false)
+
+        let audioVideoConfigAudioModeNoAudio = AudioVideoConfiguration(audioMode: .noAudio)
+        XCTAssertEqual(audioVideoConfigAudioModeNoAudio.audioMode, .noAudio)
+        XCTAssertEqual(audioVideoConfigAudioModeNoAudio.callKitEnabled, false)
+
         let audioVideoConfigCallkit = AudioVideoConfiguration(callKitEnabled: true)
-        XCTAssertEqual(audioVideoConfigCallkit.audioMode, .mono)
+        XCTAssertEqual(audioVideoConfigCallkit.audioMode, .stereo48K)
         XCTAssertEqual(audioVideoConfigCallkit.callKitEnabled, true)
     }
 }

--- a/AmazonChimeSDK/AmazonChimeSDKTests/audiovideo/DefaultAudioVideoControllerTests.swift
+++ b/AmazonChimeSDK/AmazonChimeSDKTests/audiovideo/DefaultAudioVideoControllerTests.swift
@@ -7,6 +7,7 @@
 //
 
 @testable import AmazonChimeSDK
+@testable import AmazonChimeSDKMedia
 import AVFoundation
 import Mockingbird
 import XCTest
@@ -48,7 +49,7 @@ class DefaultAudioVideoControllerTests: CommonTestCase {
             attendeeId: self.meetingSessionConfigurationMock.credentials.attendeeId,
             joinToken: self.meetingSessionConfigurationMock.credentials.joinToken,
             callKitEnabled: false,
-            audioMode: .mono
+            audioMode: .stereo48K
         )).wasCalled()
         verify(videoClientControllerMock.start()).wasCalled()
     }
@@ -64,7 +65,67 @@ class DefaultAudioVideoControllerTests: CommonTestCase {
             attendeeId: self.meetingSessionConfigurationMock.credentials.attendeeId,
             joinToken: self.meetingSessionConfigurationMock.credentials.joinToken,
             callKitEnabled: callKitEnabled,
-            audioMode: .mono
+            audioMode: .stereo48K
+        )).wasCalled()
+        verify(videoClientControllerMock.start()).wasCalled()
+    }
+
+    func testStart_mono48K_callKitDisabled() {
+        XCTAssertNoThrow(try defaultAudioVideoController.start(audioVideoConfiguration: AudioVideoConfiguration(audioMode: .mono48K, callKitEnabled: false)))
+
+        verify(audioClientControllerMock.start(
+            audioFallbackUrl: self.meetingSessionConfigurationMock.urls.audioFallbackUrl,
+            audioHostUrl: self.meetingSessionConfigurationMock.urls.audioHostUrl,
+            meetingId: self.meetingSessionConfigurationMock.meetingId,
+            attendeeId: self.meetingSessionConfigurationMock.credentials.attendeeId,
+            joinToken: self.meetingSessionConfigurationMock.credentials.joinToken,
+            callKitEnabled: false,
+            audioMode: .mono48K
+        )).wasCalled()
+        verify(videoClientControllerMock.start()).wasCalled()
+    }
+
+    func testStart_mono48K_callKitEnabled() {
+        XCTAssertNoThrow(try defaultAudioVideoController.start(audioVideoConfiguration: AudioVideoConfiguration(audioMode: .mono48K, callKitEnabled: true)))
+
+        verify(audioClientControllerMock.start(
+            audioFallbackUrl: self.meetingSessionConfigurationMock.urls.audioFallbackUrl,
+            audioHostUrl: self.meetingSessionConfigurationMock.urls.audioHostUrl,
+            meetingId: self.meetingSessionConfigurationMock.meetingId,
+            attendeeId: self.meetingSessionConfigurationMock.credentials.attendeeId,
+            joinToken: self.meetingSessionConfigurationMock.credentials.joinToken,
+            callKitEnabled: true,
+            audioMode: .mono48K
+        )).wasCalled()
+        verify(videoClientControllerMock.start()).wasCalled()
+    }
+
+    func testStart_mono16K_callKitDisabled() {
+        XCTAssertNoThrow(try defaultAudioVideoController.start(audioVideoConfiguration: AudioVideoConfiguration(audioMode: .mono16K, callKitEnabled: false)))
+
+        verify(audioClientControllerMock.start(
+            audioFallbackUrl: self.meetingSessionConfigurationMock.urls.audioFallbackUrl,
+            audioHostUrl: self.meetingSessionConfigurationMock.urls.audioHostUrl,
+            meetingId: self.meetingSessionConfigurationMock.meetingId,
+            attendeeId: self.meetingSessionConfigurationMock.credentials.attendeeId,
+            joinToken: self.meetingSessionConfigurationMock.credentials.joinToken,
+            callKitEnabled: false,
+            audioMode: .mono16K
+        )).wasCalled()
+        verify(videoClientControllerMock.start()).wasCalled()
+    }
+
+    func testStart_mono16K_callKitEnabled() {
+        XCTAssertNoThrow(try defaultAudioVideoController.start(audioVideoConfiguration: AudioVideoConfiguration(audioMode: .mono16K, callKitEnabled: true)))
+
+        verify(audioClientControllerMock.start(
+            audioFallbackUrl: self.meetingSessionConfigurationMock.urls.audioFallbackUrl,
+            audioHostUrl: self.meetingSessionConfigurationMock.urls.audioHostUrl,
+            meetingId: self.meetingSessionConfigurationMock.meetingId,
+            attendeeId: self.meetingSessionConfigurationMock.credentials.attendeeId,
+            joinToken: self.meetingSessionConfigurationMock.credentials.joinToken,
+            callKitEnabled: true,
+            audioMode: .mono16K
         )).wasCalled()
         verify(videoClientControllerMock.start()).wasCalled()
     }

--- a/AmazonChimeSDK/AmazonChimeSDKTests/audiovideo/DefaultAudioVideoFacadeTests.swift
+++ b/AmazonChimeSDK/AmazonChimeSDKTests/audiovideo/DefaultAudioVideoFacadeTests.swift
@@ -50,7 +50,7 @@ class DefaultAudioVideoFacadeTests: CommonTestCase {
     }
 
     func testStart_WithConfigArgs() {
-        let audioVideoConfiguration = AudioVideoConfiguration(audioMode: .noAudio, callKitEnabled: true)
+        let audioVideoConfiguration = AudioVideoConfiguration(audioMode: .mono48K, callKitEnabled: true)
         given(audioVideoControllerMock.start(audioVideoConfiguration: any())).willReturn()
 
         XCTAssertNoThrow(try defaultAudioVideoFacade.start(audioVideoConfiguration: audioVideoConfiguration))
@@ -63,7 +63,7 @@ class DefaultAudioVideoFacadeTests: CommonTestCase {
 
         XCTAssertNoThrow(try defaultAudioVideoFacade.start(callKitEnabled: true))
 
-        verify(audioVideoControllerMock.start(audioVideoConfiguration: any(where: { $0.audioMode == .mono && $0.callKitEnabled == true }))).wasCalled()
+        verify(audioVideoControllerMock.start(audioVideoConfiguration: any(where: { $0.audioMode == .stereo48K && $0.callKitEnabled == true }))).wasCalled()
     }
 
     func testStart_WithNoArgs() {
@@ -71,6 +71,6 @@ class DefaultAudioVideoFacadeTests: CommonTestCase {
 
         XCTAssertNoThrow(try defaultAudioVideoFacade.start())
 
-        verify(audioVideoControllerMock.start(audioVideoConfiguration: any(where: { $0.audioMode == .mono && $0.callKitEnabled == false }))).wasCalled()
+        verify(audioVideoControllerMock.start(audioVideoConfiguration: any(where: { $0.audioMode == .stereo48K && $0.callKitEnabled == false }))).wasCalled()
     }
 }

--- a/AmazonChimeSDK/AmazonChimeSDKTests/audiovideo/audio/AudioModeTests.swift
+++ b/AmazonChimeSDK/AmazonChimeSDKTests/audiovideo/audio/AudioModeTests.swift
@@ -5,13 +5,14 @@
 //  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  SPDX-License-Identifier: Apache-2.0
 //
-
 @testable import AmazonChimeSDK
 import XCTest
 
 class AudioModeTests: XCTestCase {
     func testDescriptionShouldMatch() {
-        XCTAssertEqual(AudioMode.mono.description, "mono")
         XCTAssertEqual(AudioMode.noAudio.description, "noAudio")
+        XCTAssertEqual(AudioMode.mono16K.description, "mono16K")
+        XCTAssertEqual(AudioMode.mono48K.description, "mono48K")
+        XCTAssertEqual(AudioMode.stereo48K.description, "stereo48K")
     }
 }

--- a/AmazonChimeSDK/AmazonChimeSDKTests/internal/audio/DefaultAudioClientControllerTests.swift
+++ b/AmazonChimeSDK/AmazonChimeSDKTests/internal/audio/DefaultAudioClientControllerTests.swift
@@ -38,6 +38,20 @@ class DefaultAudioClientControllerTests: CommonTestCase {
 
         given(meetingStatsCollectorMock.getMeetingStats()).will { [AnyHashable: Any]() }
 
+        given(audioSessionMock.getRecordPermission()).willReturn(.granted)
+        given(audioClientMock.startSession(any(),
+                                           basePort: any(),
+                                           callId: any(),
+                                           profileId: any(),
+                                           microphoneMute: any(),
+                                           speakerMute: any(),
+                                           isPresenter: any(),
+                                           sessionToken: any(),
+                                           audioWsUrl: any(),
+                                           callKitEnabled: any(),
+                                           appInfo: any(),
+                                           audioMode: any())).willReturn(AUDIO_CLIENT_OK)
+
         defaultAudioClientController = DefaultAudioClientController(audioClient: audioClientMock,
                                                                     audioClientObserver: audioClientObserverMock,
                                                                     audioSession: audioSessionMock,
@@ -108,19 +122,6 @@ class DefaultAudioClientControllerTests: CommonTestCase {
 
     func testStart_startedOk() {
         DefaultAudioClientController.state = .initialized
-        given(audioSessionMock.getRecordPermission()).willReturn(.granted)
-        given(audioClientMock.startSession(any(),
-                                           basePort: any(),
-                                           callId: any(),
-                                           profileId: any(),
-                                           microphoneMute: any(),
-                                           speakerMute: any(),
-                                           isPresenter: any(),
-                                           sessionToken: any(),
-                                           audioWsUrl: any(),
-                                           callKitEnabled: any(),
-                                           appInfo: any(),
-                                           audioMode: any())).willReturn(AUDIO_CLIENT_OK)
 
         XCTAssertNoThrow(try defaultAudioClientController.start(audioFallbackUrl: audioFallbackUrl,
                                                                 audioHostUrl: audioHostUrlWithPort,
@@ -150,19 +151,6 @@ class DefaultAudioClientControllerTests: CommonTestCase {
 
     func testStartWithMono48K_startedOk() {
         DefaultAudioClientController.state = .initialized
-        given(audioSessionMock.getRecordPermission()).willReturn(.granted)
-        given(audioClientMock.startSession(any(),
-                                           basePort: any(),
-                                           callId: any(),
-                                           profileId: any(),
-                                           microphoneMute: any(),
-                                           speakerMute: any(),
-                                           isPresenter: any(),
-                                           sessionToken: any(),
-                                           audioWsUrl: any(),
-                                           callKitEnabled: any(),
-                                           appInfo: any(),
-                                           audioMode: any())).willReturn(AUDIO_CLIENT_OK)
 
         XCTAssertNoThrow(try defaultAudioClientController.start(audioFallbackUrl: audioFallbackUrl,
                                                                 audioHostUrl: audioHostUrlWithPort,
@@ -192,19 +180,6 @@ class DefaultAudioClientControllerTests: CommonTestCase {
 
     func testStartWithMono16K_startedOk() {
         DefaultAudioClientController.state = .initialized
-        given(audioSessionMock.getRecordPermission()).willReturn(.granted)
-        given(audioClientMock.startSession(any(),
-                                           basePort: any(),
-                                           callId: any(),
-                                           profileId: any(),
-                                           microphoneMute: any(),
-                                           speakerMute: any(),
-                                           isPresenter: any(),
-                                           sessionToken: any(),
-                                           audioWsUrl: any(),
-                                           callKitEnabled: any(),
-                                           appInfo: any(),
-                                           audioMode: any())).willReturn(AUDIO_CLIENT_OK)
 
         XCTAssertNoThrow(try defaultAudioClientController.start(audioFallbackUrl: audioFallbackUrl,
                                                                 audioHostUrl: audioHostUrlWithPort,
@@ -234,19 +209,6 @@ class DefaultAudioClientControllerTests: CommonTestCase {
 
     func testStartWithNoAudio_startedOk() {
         DefaultAudioClientController.state = .initialized
-        given(audioSessionMock.getRecordPermission()).willReturn(.granted)
-        given(audioClientMock.startSession(any(),
-                                           basePort: any(),
-                                           callId: any(),
-                                           profileId: any(),
-                                           microphoneMute: any(),
-                                           speakerMute: any(),
-                                           isPresenter: any(),
-                                           sessionToken: any(),
-                                           audioWsUrl: any(),
-                                           callKitEnabled: any(),
-                                           appInfo: any(),
-                                           audioMode: any())).willReturn(AUDIO_CLIENT_OK)
 
         XCTAssertNoThrow(try defaultAudioClientController.start(audioFallbackUrl: audioFallbackUrl,
                                                                 audioHostUrl: audioHostUrlWithPort,
@@ -276,7 +238,6 @@ class DefaultAudioClientControllerTests: CommonTestCase {
 
     func testStart_failedToStart() {
         DefaultAudioClientController.state = .initialized
-        given(audioSessionMock.getRecordPermission()).willReturn(.granted)
         given(audioClientMock.startSession(any(),
                                            basePort: any(),
                                            callId: any(),

--- a/AmazonChimeSDK/AmazonChimeSDKTests/internal/audio/DefaultAudioClientControllerTests.swift
+++ b/AmazonChimeSDK/AmazonChimeSDKTests/internal/audio/DefaultAudioClientControllerTests.swift
@@ -6,8 +6,8 @@
 //  SPDX-License-Identifier: Apache-2.0
 //
 
+@testable import AmazonChimeSDKMedia
 @testable import AmazonChimeSDK
-import AmazonChimeSDKMedia
 import Mockingbird
 import XCTest
 
@@ -36,7 +36,7 @@ class DefaultAudioClientControllerTests: CommonTestCase {
         meetingStatsCollectorMock = mock(MeetingStatsCollector.self)
         activeSpeakerMock = mock(ActiveSpeakerDetectorFacade.self)
 
-        given(meetingStatsCollectorMock.getMeetingStats()).will { return [AnyHashable: Any]() }
+        given(meetingStatsCollectorMock.getMeetingStats()).will { [AnyHashable: Any]() }
 
         defaultAudioClientController = DefaultAudioClientController(audioClient: audioClientMock,
                                                                     audioClientObserver: audioClientObserverMock,
@@ -70,7 +70,7 @@ class DefaultAudioClientControllerTests: CommonTestCase {
                                                                     attendeeId: attendeeId,
                                                                     joinToken: joinToken,
                                                                     callKitEnabled: callKitEnabled,
-                                                                    audioMode: .mono))
+                                                                    audioMode: .stereo48K))
         verify(audioLockMock.lock()).wasCalled()
         verify(audioLockMock.unlock()).wasCalled()
     }
@@ -85,7 +85,7 @@ class DefaultAudioClientControllerTests: CommonTestCase {
                                                                     attendeeId: attendeeId,
                                                                     joinToken: joinToken,
                                                                     callKitEnabled: callKitEnabled,
-                                                                    audioMode: .mono))
+                                                                    audioMode: .stereo48K))
         verify(audioLockMock.lock()).wasCalled()
         verify(audioLockMock.unlock()).wasCalled()
     }
@@ -119,7 +119,8 @@ class DefaultAudioClientControllerTests: CommonTestCase {
                                            sessionToken: any(),
                                            audioWsUrl: any(),
                                            callKitEnabled: any(),
-                                           appInfo: any())).willReturn(AUDIO_CLIENT_OK)
+                                           appInfo: any(),
+                                           audioMode: any())).willReturn(AUDIO_CLIENT_OK)
 
         XCTAssertNoThrow(try defaultAudioClientController.start(audioFallbackUrl: audioFallbackUrl,
                                                                 audioHostUrl: audioHostUrlWithPort,
@@ -127,7 +128,7 @@ class DefaultAudioClientControllerTests: CommonTestCase {
                                                                 attendeeId: attendeeId,
                                                                 joinToken: joinToken,
                                                                 callKitEnabled: callKitEnabled,
-                                                                audioMode: .mono))
+                                                                audioMode: .stereo48K))
         verify(audioLockMock.lock()).wasCalled()
         verify(audioClientObserverMock.notifyAudioClientObserver(observerFunction: any())).wasCalled()
         verify(audioClientMock.startSession(self.audioHostUrl,
@@ -140,7 +141,92 @@ class DefaultAudioClientControllerTests: CommonTestCase {
                                             sessionToken: self.joinToken,
                                             audioWsUrl: self.audioFallbackUrl,
                                             callKitEnabled: false,
-                                            appInfo: any())).wasCalled()
+                                            appInfo: any(),
+                                            audioMode: .Stereo48K)).wasCalled()
+        verify(eventAnalyticsControllerMock.publishEvent(name: .meetingStartRequested)).wasCalled()
+        XCTAssertEqual(.started, DefaultAudioClientController.state)
+        verify(audioLockMock.unlock()).wasCalled()
+    }
+
+    func testStartWithMono48K_startedOk() {
+        DefaultAudioClientController.state = .initialized
+        given(audioSessionMock.getRecordPermission()).willReturn(.granted)
+        given(audioClientMock.startSession(any(),
+                                           basePort: any(),
+                                           callId: any(),
+                                           profileId: any(),
+                                           microphoneMute: any(),
+                                           speakerMute: any(),
+                                           isPresenter: any(),
+                                           sessionToken: any(),
+                                           audioWsUrl: any(),
+                                           callKitEnabled: any(),
+                                           appInfo: any(),
+                                           audioMode: any())).willReturn(AUDIO_CLIENT_OK)
+
+        XCTAssertNoThrow(try defaultAudioClientController.start(audioFallbackUrl: audioFallbackUrl,
+                                                                audioHostUrl: audioHostUrlWithPort,
+                                                                meetingId: meetingId,
+                                                                attendeeId: attendeeId,
+                                                                joinToken: joinToken,
+                                                                callKitEnabled: callKitEnabled,
+                                                                audioMode: .mono48K))
+        verify(audioLockMock.lock()).wasCalled()
+        verify(audioClientObserverMock.notifyAudioClientObserver(observerFunction: any())).wasCalled()
+        verify(audioClientMock.startSession(self.audioHostUrl,
+                                            basePort: 1820,
+                                            callId: self.meetingId,
+                                            profileId: self.attendeeId,
+                                            microphoneMute: false,
+                                            speakerMute: false,
+                                            isPresenter: true,
+                                            sessionToken: self.joinToken,
+                                            audioWsUrl: self.audioFallbackUrl,
+                                            callKitEnabled: false,
+                                            appInfo: any(),
+                                            audioMode: .Mono48K)).wasCalled()
+        verify(eventAnalyticsControllerMock.publishEvent(name: .meetingStartRequested)).wasCalled()
+        XCTAssertEqual(.started, DefaultAudioClientController.state)
+        verify(audioLockMock.unlock()).wasCalled()
+    }
+
+    func testStartWithMono16K_startedOk() {
+        DefaultAudioClientController.state = .initialized
+        given(audioSessionMock.getRecordPermission()).willReturn(.granted)
+        given(audioClientMock.startSession(any(),
+                                           basePort: any(),
+                                           callId: any(),
+                                           profileId: any(),
+                                           microphoneMute: any(),
+                                           speakerMute: any(),
+                                           isPresenter: any(),
+                                           sessionToken: any(),
+                                           audioWsUrl: any(),
+                                           callKitEnabled: any(),
+                                           appInfo: any(),
+                                           audioMode: any())).willReturn(AUDIO_CLIENT_OK)
+
+        XCTAssertNoThrow(try defaultAudioClientController.start(audioFallbackUrl: audioFallbackUrl,
+                                                                audioHostUrl: audioHostUrlWithPort,
+                                                                meetingId: meetingId,
+                                                                attendeeId: attendeeId,
+                                                                joinToken: joinToken,
+                                                                callKitEnabled: callKitEnabled,
+                                                                audioMode: .mono16K))
+        verify(audioLockMock.lock()).wasCalled()
+        verify(audioClientObserverMock.notifyAudioClientObserver(observerFunction: any())).wasCalled()
+        verify(audioClientMock.startSession(self.audioHostUrl,
+                                            basePort: 1820,
+                                            callId: self.meetingId,
+                                            profileId: self.attendeeId,
+                                            microphoneMute: false,
+                                            speakerMute: false,
+                                            isPresenter: true,
+                                            sessionToken: self.joinToken,
+                                            audioWsUrl: self.audioFallbackUrl,
+                                            callKitEnabled: false,
+                                            appInfo: any(),
+                                            audioMode: .Mono16K)).wasCalled()
         verify(eventAnalyticsControllerMock.publishEvent(name: .meetingStartRequested)).wasCalled()
         XCTAssertEqual(.started, DefaultAudioClientController.state)
         verify(audioLockMock.unlock()).wasCalled()
@@ -159,7 +245,8 @@ class DefaultAudioClientControllerTests: CommonTestCase {
                                            sessionToken: any(),
                                            audioWsUrl: any(),
                                            callKitEnabled: any(),
-                                           appInfo: any())).willReturn(AUDIO_CLIENT_OK)
+                                           appInfo: any(),
+                                           audioMode: any())).willReturn(AUDIO_CLIENT_OK)
 
         XCTAssertNoThrow(try defaultAudioClientController.start(audioFallbackUrl: audioFallbackUrl,
                                                                 audioHostUrl: audioHostUrlWithPort,
@@ -180,7 +267,8 @@ class DefaultAudioClientControllerTests: CommonTestCase {
                                             sessionToken: self.joinToken,
                                             audioWsUrl: self.audioFallbackUrl,
                                             callKitEnabled: false,
-                                            appInfo: any())).wasCalled()
+                                            appInfo: any(),
+                                            audioMode: .NoAudio)).wasCalled()
         verify(eventAnalyticsControllerMock.publishEvent(name: .meetingStartRequested)).wasCalled()
         XCTAssertEqual(.started, DefaultAudioClientController.state)
         verify(audioLockMock.unlock()).wasCalled()
@@ -199,7 +287,8 @@ class DefaultAudioClientControllerTests: CommonTestCase {
                                            sessionToken: any(),
                                            audioWsUrl: any(),
                                            callKitEnabled: any(),
-                                           appInfo: any())).willReturn(AUDIO_CLIENT_ERR)
+                                           appInfo: any(),
+                                           audioMode: any())).willReturn(AUDIO_CLIENT_ERR)
 
         XCTAssertThrowsError(try defaultAudioClientController.start(audioFallbackUrl: audioFallbackUrl,
                                                                     audioHostUrl: audioHostUrlWithPort,
@@ -207,7 +296,7 @@ class DefaultAudioClientControllerTests: CommonTestCase {
                                                                     attendeeId: attendeeId,
                                                                     joinToken: joinToken,
                                                                     callKitEnabled: callKitEnabled,
-                                                                    audioMode: .mono))
+                                                                    audioMode: .stereo48K))
         verify(audioLockMock.lock()).wasCalled()
         verify(audioClientObserverMock.notifyAudioClientObserver(observerFunction: any())).wasCalled()
         verify(audioClientMock.startSession(self.audioHostUrl,
@@ -220,7 +309,8 @@ class DefaultAudioClientControllerTests: CommonTestCase {
                                             sessionToken: self.joinToken,
                                             audioWsUrl: self.audioFallbackUrl,
                                             callKitEnabled: false,
-                                            appInfo: any())).wasCalled()
+                                            appInfo: any(),
+                                            audioMode: .Stereo48K)).wasCalled()
         XCTAssertEqual(.initialized, DefaultAudioClientController.state)
         verify(audioLockMock.unlock()).wasCalled()
     }

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/Base.lproj/Main.storyboard
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/Base.lproj/Main.storyboard
@@ -53,7 +53,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="U4C-4u-Vzl" userLabel="Join Config">
-                                <rect key="frame" x="32" y="477" width="350" height="151"/>
+                                <rect key="frame" x="32" y="477" width="350" height="190"/>
                                 <subviews>
                                     <pickerView contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="j1Y-t4-xgU">
                                         <rect key="frame" x="0.0" y="0.0" width="350" height="70"/>
@@ -65,23 +65,18 @@
                                             <constraint firstAttribute="height" constant="70" id="RZy-gv-cbQ"/>
                                         </constraints>
                                     </pickerView>
-                                    <stackView opaque="NO" contentMode="scaleToFill" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="57w-s6-L9Q" userLabel="Audio Config">
-                                        <rect key="frame" x="75.000000000000014" y="80" width="200.33333333333337" height="31"/>
-                                        <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Audio output/input" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="8Hk-p1-iUS">
-                                                <rect key="frame" x="0.0" y="0.0" width="141.33333333333334" height="31"/>
-                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                <nil key="textColor"/>
-                                                <nil key="highlightedColor"/>
-                                            </label>
-                                            <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="P7T-QG-xAv">
-                                                <rect key="frame" x="151.33333333333331" y="0.0" width="51" height="31"/>
-                                                <accessibility key="accessibilityConfiguration" identifier="Audio Switch"/>
-                                            </switch>
-                                        </subviews>
-                                    </stackView>
+                                    <pickerView contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="PzT-6X-6dW">
+                                        <rect key="frame" x="0.0" y="80" width="350" height="70"/>
+                                        <accessibility key="accessibilityConfiguration" identifier="AudioMode Options">
+                                            <bool key="isElement" value="YES"/>
+                                        </accessibility>
+                                        <constraints>
+                                            <constraint firstAttribute="width" constant="350" id="du2-fy-4av"/>
+                                            <constraint firstAttribute="height" constant="70" id="tMM-3b-C9y"/>
+                                        </constraints>
+                                    </pickerView>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="EBv-5d-gOg">
-                                        <rect key="frame" x="130.66666666666666" y="121" width="89" height="30"/>
+                                        <rect key="frame" x="130.66666666666666" y="160" width="89" height="30"/>
                                         <accessibility key="accessibilityConfiguration" identifier="Join Without CallKit"/>
                                         <state key="normal" title="Join Meeting"/>
                                         <connections>
@@ -89,6 +84,11 @@
                                         </connections>
                                     </button>
                                 </subviews>
+                                <constraints>
+                                    <constraint firstItem="PzT-6X-6dW" firstAttribute="top" secondItem="j1Y-t4-xgU" secondAttribute="bottom" id="34a-7D-gy6"/>
+                                    <constraint firstAttribute="trailing" secondItem="PzT-6X-6dW" secondAttribute="trailing" id="LXi-pP-wLT"/>
+                                    <constraint firstItem="PzT-6X-6dW" firstAttribute="leading" secondItem="U4C-4u-Vzl" secondAttribute="leading" id="dfH-F5-02T"/>
+                                </constraints>
                             </stackView>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="66Y-WJ-mRM">
                                 <rect key="frame" x="268" y="60" width="106" height="30"/>
@@ -121,7 +121,7 @@
                         </constraints>
                     </view>
                     <connections>
-                        <outlet property="audioSwitch" destination="P7T-QG-xAv" id="vDM-Tm-cqb"/>
+                        <outlet property="audioModeOptionsPicker" destination="PzT-6X-6dW" id="rS6-Jg-cyu"/>
                         <outlet property="callKitOptionsPicker" destination="j1Y-t4-xgU" id="aLn-e0-4WW"/>
                         <outlet property="debugSettingsButton" destination="66Y-WJ-mRM" id="eul-Gi-QFC"/>
                         <outlet property="joinButton" destination="EBv-5d-gOg" id="FfN-4U-iAy"/>

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/JoiningViewController.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/JoiningViewController.swift
@@ -49,30 +49,14 @@ class JoiningViewController: UIViewController, UITextFieldDelegate {
 
     @IBAction func joinButton(_: UIButton) {
         // CallKit Option
-        var callKitOption: CallKitOption = .disabled
-        switch callKitOptionsPicker.selectedRow(inComponent: 0) {
-        case 1:
-            callKitOption = .incoming
+        let callKitOption = getSelectedCallKitOption()
+        if (callKitOption == .incoming) {
             view.makeToast("You can background the app or lock screen while waiting",
                            duration: incomingCallKitDelayInSeconds)
-        case 2:
-            callKitOption = .outgoing
-        default:
-            callKitOption = .disabled
         }
 
         // Audio Mode
-        var audioMode: AudioMode = .stereo48K
-        switch audioModeOptionsPicker.selectedRow(inComponent: 0) {
-        case 1:
-            audioMode = .mono48K
-        case 2:
-            audioMode = .mono16K
-        case 3:
-            audioMode = .noAudio
-        default:
-            audioMode = .stereo48K
-        }
+        let audioMode = getSelectedAudioMode()
 
         joinMeeting(audioVideoConfig: AudioVideoConfiguration(audioMode: audioMode, callKitEnabled: callKitOption != .disabled),
                     callKitOption: callKitOption
@@ -92,6 +76,30 @@ class JoiningViewController: UIViewController, UITextFieldDelegate {
     func textFieldShouldReturn(_ textField: UITextField) -> Bool {
         textField.resignFirstResponder()
         return true
+    }
+
+    func getSelectedCallKitOption() -> CallKitOption {
+        switch callKitOptionsPicker.selectedRow(inComponent: 0) {
+        case 1:
+            return .incoming
+        case 2:
+            return .outgoing
+        default:
+            return .disabled
+        }
+    }
+
+    func getSelectedAudioMode() -> AudioMode {
+        switch audioModeOptionsPicker.selectedRow(inComponent: 0) {
+        case 1:
+            return .mono48K
+        case 2:
+            return .mono16K
+        case 3:
+            return .noAudio
+        default:
+            return .stereo48K
+        }
     }
 
     func joinMeeting(audioVideoConfig: AudioVideoConfiguration, callKitOption: CallKitOption) {

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/JoiningViewController.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/JoiningViewController.swift
@@ -16,11 +16,12 @@ class JoiningViewController: UIViewController, UITextFieldDelegate {
     @IBOutlet var nameTextField: UITextField!
     @IBOutlet var versionLabel: UILabel!
     @IBOutlet var callKitOptionsPicker: UIPickerView!
-    @IBOutlet var audioSwitch: UISwitch!
+    @IBOutlet var audioModeOptionsPicker: UIPickerView!
     @IBOutlet var joinButton: UIButton!
     @IBOutlet var debugSettingsButton: UIButton!
 
     var callKitOptions = ["Don't use CallKit", "CallKit as Incoming in 10s", "CallKit as Outgoing"]
+    var audioModeOptions = ["Stereo/48KHz Audio", "Mono/48KHz Audio", "Mono/16KHz Audio", "No Audio"]
 
     private let toastDisplayDuration = 2.0
     private let mainStoryboard = UIStoryboard(name: "Main", bundle: nil)
@@ -33,6 +34,9 @@ class JoiningViewController: UIViewController, UITextFieldDelegate {
 
         callKitOptionsPicker.delegate = self
         callKitOptionsPicker.dataSource = self
+
+        audioModeOptionsPicker.delegate = self
+        audioModeOptionsPicker.dataSource = self
 
         setupHideKeyboardOnTap()
         versionLabel.text = "amazon-chime-sdk-ios@\(Versioning.sdkVersion())"
@@ -58,9 +62,16 @@ class JoiningViewController: UIViewController, UITextFieldDelegate {
         }
 
         // Audio Mode
-        var audioMode: AudioMode = .mono
-        if !audioSwitch.isOn {
+        var audioMode: AudioMode = .stereo48K
+        switch audioModeOptionsPicker.selectedRow(inComponent: 0) {
+        case 1:
+            audioMode = .mono48K
+        case 2:
+            audioMode = .mono16K
+        case 3:
             audioMode = .noAudio
+        default:
+            audioMode = .stereo48K
         }
 
         joinMeeting(audioVideoConfig: AudioVideoConfiguration(audioMode: audioMode, callKitEnabled: callKitOption != .disabled),
@@ -114,10 +125,19 @@ class JoiningViewController: UIViewController, UITextFieldDelegate {
 
 extension JoiningViewController: UIPickerViewDelegate {
     func pickerView(_ pickerView: UIPickerView, titleForRow row: Int, forComponent _: Int) -> String? {
-        if row >= callKitOptions.count {
+        if pickerView == callKitOptionsPicker {
+            if row >= callKitOptions.count {
+                return nil
+            }
+            return callKitOptions[row]
+        } else if pickerView == audioModeOptionsPicker {
+            if row >= audioModeOptions.count {
+                return nil
+            }
+            return audioModeOptions[row]
+        } else {
             return nil
         }
-        return callKitOptions[row]
     }
 }
 
@@ -127,6 +147,12 @@ extension JoiningViewController: UIPickerViewDataSource {
     }
 
     func pickerView(_ pickerView: UIPickerView, numberOfRowsInComponent _: Int) -> Int {
-        return callKitOptions.count
+        if pickerView == callKitOptionsPicker {
+            return callKitOptions.count
+        } else if pickerView == audioModeOptionsPicker {
+            return audioModeOptions.count
+        } else {
+            return 0
+        }
     }
 }

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/MeetingViewController.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/MeetingViewController.swift
@@ -50,7 +50,7 @@ class MeetingViewController: UIViewController {
 
     // Metrics
     @IBOutlet var metricsTable: UITableView!
-    
+
     // Chat View
     @IBOutlet var chatView: UIView!
     @IBOutlet var chatMessageTable: UITableView!
@@ -67,7 +67,7 @@ class MeetingViewController: UIViewController {
 
     // Local var
     private let logger = ConsoleLogger(name: "MeetingViewController")
-    
+
     // MARK: Override functions
 
     override func viewDidLoad() {
@@ -156,7 +156,6 @@ class MeetingViewController: UIViewController {
             if let tileId = tileId,
                let screenRenderView = self?.screenRenderView,
                let meetingModel = meetingModel {
-
                 meetingModel.bind(videoRenderView: screenRenderView, tileId: tileId)
             }
         }
@@ -400,7 +399,7 @@ class MeetingViewController: UIViewController {
                                                 meetingModel.setVoiceFocusEnabled(enabled: !isVoiceFocusEnabled)
                                              })
         optionMenu.addAction(voiceFocusAction)
-        
+
         let isLiveTranscriptionEnabled = meetingModel.captionsModel.isLiveTranscriptionEnabled
         let nextLiveTranscriptionStatus = nextOnOrOff(current: isLiveTranscriptionEnabled)
         let liveTranscriptionAction = UIAlertAction(title: "Turn \(nextLiveTranscriptionStatus) Live Transcription",
@@ -409,7 +408,7 @@ class MeetingViewController: UIViewController {
                                                 meetingModel.setLiveTranscriptionEnabled(enabled: !isLiveTranscriptionEnabled)
                                              })
         optionMenu.addAction(liveTranscriptionAction)
-        
+
         // We can only access torch and apply filter on external video source
         if meetingModel.videoModel.isUsingExternalVideoSource {
             let isTorchOn = meetingModel.videoModel.customSource.torchEnabled

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ### Added
 * Added APIs for Audio Video configuration i.e `AudioVideoConfiguration` to be used during a meeting session.
-* Added support for joining meetings without audio i.e `AudioMode.NoAudio` or with audio using one of `AudioMode.Mono16K`, `AudioMode.Mono48K` and `AudioMode.Stereo48K` audio modes. The `AudioMode.Stereo48K` will be set as the default audio mode if not explicitly specified when starting the audio session.
+* Added support for joining meetings without audio i.e `AudioMode.NoAudio` or with audio using one of `AudioMode.Mono16K`, `AudioMode.Mono48K` and `AudioMode.Stereo48K` audio modes.
+* **Breaking** The `AudioMode.Stereo48K` will be set as the default audio mode if not explicitly specified when starting the audio session. Earlier, Mono/16KHz audio was the default and the only audio mode supported.
 * Added an optional method `onAttendeesJoinedWithoutAudio` in `RealtimeObserver` to communicate the status of attendees who joined without audio.
 * Supports integration with Amazon Transcribe and Amazon Transcribe Medical for live transcription. The Amazon Chime Service uses its active talker algorithm to select the top two active talkers, and sends their audio to Amazon Transcribe (or Amazon Transcribe Medical) in your AWS account. User-attributed transcriptions are then sent directly to every meeting attendee via data messages. Use transcriptions to overlay subtitles, build a transcript, or perform real-time content analysis. For more information, visit [the live transcription guide](https://docs.aws.amazon.com/chime/latest/dg/meeting-transcription.html).
 * [Demo] Added ways to join a meeting without audio or with audio using various audio modes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,10 @@
 
 ### Added
 * Added APIs for Audio Video configuration i.e `AudioVideoConfiguration` to be used during a meeting session.
-* Added support for joining meetings without audio i.e `AudioMode.NoAudio`.
+* Added support for joining meetings without audio i.e `AudioMode.NoAudio` or with audio using one of `AudioMode.Mono16K`, `AudioMode.Mono48K` and `AudioMode.Stereo48K` audio modes. The `AudioMode.Stereo48K` will be set as the default audio mode if not explicitly specified when starting the audio session.
 * Added an optional method `onAttendeesJoinedWithoutAudio` in `RealtimeObserver` to communicate the status of attendees who joined without audio.
 * Supports integration with Amazon Transcribe and Amazon Transcribe Medical for live transcription. The Amazon Chime Service uses its active talker algorithm to select the top two active talkers, and sends their audio to Amazon Transcribe (or Amazon Transcribe Medical) in your AWS account. User-attributed transcriptions are then sent directly to every meeting attendee via data messages. Use transcriptions to overlay subtitles, build a transcript, or perform real-time content analysis. For more information, visit [the live transcription guide](https://docs.aws.amazon.com/chime/latest/dg/meeting-transcription.html).
-* [Demo] Added ways to join a meeting without audio.
+* [Demo] Added ways to join a meeting without audio or with audio using various audio modes.
 * [Demo] Added meeting captions functionality based on the live transcription APIs. You will need to have a serverless deployment to create new AWS Lambda endpoints for live transcription. Follow [the live transcription guide](https://docs.aws.amazon.com/chime/latest/dg/meeting-transcription.html) to create necessary service-linked role so that the demo app can call Amazon Transcribe and Amazon Transcribe Medical on your behalf.
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -160,6 +160,13 @@ You need to start the meeting session to start sending and receiving audio. Make
 meetingSession.audioVideo.start()
 ```
 
+The default audio format is Stereo/48KHz i.e Stereo Audio with 48KHz sampling rate (stereo48K). Other supported audio formats include Mono/48KHz (mono48K) or Mono/16KHz (mono16K). You can specify a non-default audio mode in `AudioVideoConfiguration`, and then start the meeting session.
+
+```swift
+var audioVideoConfig = AudioVideoConfiguration()
+meetingSession.audioVideo.start(audioVideoConfiguration: audioVideoConfig)
+```
+
 #### Use case 2. Add an observer to receive audio and video session life cycle events.
 
 > Note: To avoid missing any events, add an observer before the session starts. You can remove the observer by calling meetingSession.audioVideo.removeAudioVideoObserver(observer).
@@ -254,12 +261,22 @@ let activeAudioDevice = meetingSession.audioVideo.getActiveAudioDevice()
 
 ### Audio
 
-> Note: So far, you've added observers to receive device and session lifecycle events. In the following use cases, you'll use the real-time API methods to send and receive volume indicators and control mute state.
+#### Use case 8. Choose the audio configuration.
+
 > Attendees can join a meeting with or without audio.
 > When joining a meeting with audio, *Mono/16KHz*, *Mono/48KHz* and *Stereo/48KHz* are supported. *Stereo/48KHz* will be set as the default audio mode if not explicitly specified when starting the audio session.
 > Attendees who join without audio aka Checked-In attendees will have no audio through their Mic and Speaker. They can still enable their video and view videos of other attendees. No volume and signal updates for Checked-In attendees will be delivered to other attendees in the meeting. Attendees may want to join a meeting without audio if they just want to be shown as present in the meeting and share or view videos but are using a different audio source. For example, multiple attendees joining a meeting from a conference room may want to use common audio source installed in the conference room.
 
-#### Use case 8. Mute and unmute an audio input.
+```swift
+meetingSession.audioVideo.start() // starts the audio video session with Stereo/48KHz audio and callkit disabled
+
+meetingSession.audioVideo.start(audioVideoConfiguration) // starts the audio video session with the specified [AudioVideoConfiguration]
+```
+
+> Note: So far, you've added observers to receive device and session lifecycle events. In the following use cases, you'll use the real-time API methods to send and receive volume indicators and control mute state.
+> Attendees can join a meeting with or without audio.
+
+#### Use case 9. Mute and unmute an audio input.
 
 ```swift
 let muted = meetingSession.audioVideo.realtimeLocalMute() // returns true if muted, false if failed
@@ -267,7 +284,7 @@ let muted = meetingSession.audioVideo.realtimeLocalMute() // returns true if mut
 let unmuted = meetingSession.audioVideo.realtimeLocalUnmute // returns true if unmuted, false if failed
 ```
 
-#### Use case 9. Add an observer to observe realtime events such as volume changes/signal change/muted status of a specific attendee.
+#### Use case 10. Add an observer to observe realtime events such as volume changes/signal change/muted status of a specific attendee.
 
 You can use this to build real-time indicators UI and get them updated for changes delivered by the array.
 
@@ -322,7 +339,7 @@ class MyRealtimeObserver: RealtimeObserver {
 }
 ```
 
-#### Use case 10. Detect active speakers and active scores of speakers.
+#### Use case 11. Detect active speakers and active scores of speakers.
 
 You can use the `activeSpeakerDidDetect` event to enlarge or emphasize the most active speaker’s video tile if available. By setting the `scoreCallbackIntervalMs` and implementing `activeSpeakerScoreDidChange`, you can receive scores of the active speakers periodically.
 
@@ -371,7 +388,7 @@ class MyActiveSpeakerObserver: ActiveSpeakerObserver {
 
 You can find more details on adding/removing/viewing video from [Building a meeting application on ios using the Amazon Chime SDK](https://aws.amazon.com/blogs/business-productivity/building-a-meeting-application-on-ios-using-the-amazon-chime-sdk/).
 
-#### Use case 11. Start receiving remote video.
+#### Use case 12. Start receiving remote video.
 
 You can call `startRemoteVideo` to start receiving remote videos, as this doesn’t happen by default.
 
@@ -379,7 +396,7 @@ You can call `startRemoteVideo` to start receiving remote videos, as this doesn�
 meetingSession.audioVideo.startRemoteVideo()
 ```
 
-#### Use case 12. Stop receiving remote video.
+#### Use case 13. Stop receiving remote video.
 
 `stopRemoteVideo` stops receiving remote videos and triggers `onVideoTileRemoved` for existing remote videos.
 
@@ -387,7 +404,7 @@ meetingSession.audioVideo.startRemoteVideo()
 meetingSession.audioVideo.stopRemoteVideo()
 ```
 
-#### Use case 13. View remote video tile.
+#### Use case 14. View remote video tile.
 
 ```swift
 class MyVideoTileObserver: VideoTileObserver {
@@ -410,7 +427,7 @@ class MyVideoTileObserver: VideoTileObserver {
 }
 ```
 
-#### Use case 14. Start sharing your video.
+#### Use case 15. Start sharing your video.
 
 ```swift
 // Use internal camera capture for the local video
@@ -422,13 +439,13 @@ meetingSession.audioVideo.switchCamera()
 // Or you can inject custom video source for local video, see custom video guide
 ```
 
-#### Use case 15. Stop sharing your video.
+#### Use case 16. Stop sharing your video.
 
 ```swift
 meetingSession.audioVideo.stopLocalVideo()
 ```
 
-#### Use case 16. View local video.
+#### Use case 17. View local video.
 
 > Note: The local video should be mirrored. Set VideoRenderView.mirror = true
 
@@ -459,7 +476,7 @@ For more advanced video tile management, take a look at  [Video Pagination](http
 >
 > For example, your attendee ID is "my-id". When you call `meetingSession.audioVideo.startContentShare`, the content attendee "my-id#content" will join the session and share your content.
 
-#### Use case 17. Start sharing your screen or content.
+#### Use case 18. Start sharing your screen or content.
 
 ```swift
 class MyContentShareObserver: ContentShareObserver {
@@ -480,12 +497,12 @@ class MyContentShareObserver: ContentShareObserver {
 
 See [Content Share](https://github.com/aws/amazon-chime-sdk-ios/blob/master/guides/content_share.md) for more details.
 
-#### Use case 18. Stop sharing your screen or content.
+#### Use case 19. Stop sharing your screen or content.
 ```swift
 meetingSession.audioVideo.stopContentShare()
 ```
 
-#### Use case 19. View attendee content or screens.
+#### Use case 20. View attendee content or screens.
 
 Chime SDK allows two simultaneous content shares per meeting. Remote content shares will trigger `onVideoTileAdded`, while local share will not. To render the video for preview, add a `VideoSink` to the `VideoSource` in the `ContentShareSource`.
 
@@ -514,7 +531,7 @@ class MyVideoTileObserver: VideoTileObserver {
 
 ### Metrics
 
-#### Use case 20. Add an observer to receive the meeting metrics.
+#### Use case 21. Add an observer to receive the meeting metrics.
 
 See `ObservableMetric` for more available metrics and to monitor audio, video, and content share quality.
 
@@ -530,7 +547,7 @@ class MyMetricsObserver: MetricsObserver {
 
 ### Data Message
 
-#### Use case 21. Add an observer to receive data message.
+#### Use case 22. Add an observer to receive data message.
 
 You can receive real-time messages from multiple topics after starting the meeting session.
 
@@ -547,7 +564,7 @@ class MyDataMessageObserver: DataMessageObserver {
 }
 ```
 
-#### Use case 22. Send data message.
+#### Use case 23. Send data message.
 
 You can send real time message to any topic, to which the observers that have subscribed will be notified.
 
@@ -575,7 +592,7 @@ do {
 
 > Note: Make sure to remove all the observers and release resources you have added to avoid any memory leaks.
 
-#### Use case 23. Stop a session.
+#### Use case 24. Stop a session.
 
 ```swift
 class MyAudioVideoObserver: AudioVideoObserver {
@@ -597,7 +614,7 @@ class MyAudioVideoObserver: AudioVideoObserver {
 
 Amazon Voice Focus reduces the background noise in the meeting for better meeting experience. For more details, see [Amazon Voice Focus](https://github.com/aws/amazon-chime-sdk-ios/blob/master/guides/api_overview.md#11-using-amazon-voice-focus-optional).
 
-#### Use case 24. Enable/Disable Amazon Voice Focus.
+#### Use case 25. Enable/Disable Amazon Voice Focus.
 
 ```swift
 val enabled = audioVideo.realtimeSetVoiceFocusEnabled(true) // enabling Amazon Voice Focus successful

--- a/README.md
+++ b/README.md
@@ -256,6 +256,7 @@ let activeAudioDevice = meetingSession.audioVideo.getActiveAudioDevice()
 
 > Note: So far, you've added observers to receive device and session lifecycle events. In the following use cases, you'll use the real-time API methods to send and receive volume indicators and control mute state.
 > Attendees can join a meeting with or without audio.
+> When joining a meeting with audio, *Mono/16KHz*, *Mono/48KHz* and *Stereo/48KHz* are supported. *Stereo/48KHz* will be set as the default audio mode if not explicitly specified when starting the audio session.
 > Attendees who join without audio aka Checked-In attendees will have no audio through their Mic and Speaker. They can still enable their video and view videos of other attendees. No volume and signal updates for Checked-In attendees will be delivered to other attendees in the meeting. Attendees may want to join a meeting without audio if they just want to be shown as present in the meeting and share or view videos but are using a different audio source. For example, multiple attendees joining a meeting from a conference room may want to use common audio source installed in the conference room.
 
 #### Use case 8. Mute and unmute an audio input.


### PR DESCRIPTION
### Issue #, if available:
N/A

### Description of changes:
**SDK**
* Updated `AudioMode` enum with values `stereo48K`, `mono48K`, `mono16K` and `noAudio`
> * The  `stereo48K` corresponds to 48KHz Stereo Audio
> * The  `mono48K` corresponds to 48KHz Mono Audio
> * The  `mono16K` corresponds to 16KHz Mono Audio
> * The  `noAudio` corresponds to No Audio
* The *Stereo/48KHz* Audio will now be the default Audio Mode, if none is explicitly specified when starting the audio session. Historically, the default and the only Audio Mode has been *Mono/16KHz* Audio.
* The Audio Mode specified when starting the audio session will be passed onto the Audio Client when calling the `startSession` API.
* Updated Unit Tests
* Updated README and CHANGELOG.

**Demo App**
* Removed the Audio switch, and instead added a Picker in the `JoiningViewController` to pick the Audio Mode when joining a meeting.

### Testing done:

#### Manual test cases (add more as needed):
Following are the manual testing scenarios performed by Audio Team (@zhemitu-amzn)
* Tested joining meeting with Stereo/48KHz
* Tested joining meeting with Mono/48KHz
* Tested joining meeting with Mono/16KHz
* Tested joining meeting with No Audio

*Endpoint Used for Testing: https://wmvhgew0bi.execute-api.us-east-1.amazonaws.com/Prod*

- [x] Join meeting without CallKit
- [x] Join meeting with CallKit as Incoming
- [x] Join meeting with CallKit as Outgoing
- [x] Leave meeting
- [x] Rejoin meeting
- [x] See metrics
- [x] See attendee presence
- [x] Send audio
- [x] Receive audio
- [x] Mute self
- [x] Unmute self
- [x] See local mute indicator when muted
- [x] See remote mute indicator when other is muted
- [x] Enable and disable local video
- [x] Enable and disable remote video from remote side
- [x] Send local video
- [x] Pause and resume remote video
- [x] Switch local camera
- [x] Receive remote screen share

#### Integration validation (required before release)

- [ ] Unit tests pass
- [ ] Build SDK against simulator with release options
- [ ] Build SDK against device with release options
- [ ] Build SDK against simulator with debug options
- [ ] Build SDK against device with debug options
- [ ] Test Demo against simulator with SDK (debug build) in workspace
- [ ] Test Demo against device with SDK (debug build) in workspace
- [ ] Test DemoObjC against simulator with SDK (debug build) in workspace
- [ ] Test DemoObjC against device with SDK (debug build) in workspace
- [ ] Test Demo against simulator with SDK.framework (release build)
- [ ] Test Demo against device with SDK.framework (release build)
- [ ] Test DemoObjC against simulator with SDK.framework (release build)
- [ ] Test DemoObjC against device with SDK.framework (release build)

### Screenshots, if available:
![AudioModes_Mono_Stereo](https://user-images.githubusercontent.com/84412426/140873056-1f808646-80d1-448f-96ea-dbfe5f823546.png)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
